### PR TITLE
Create WebWorld

### DIFF
--- a/release files/momodoramoonlitfarewell/__init__.py
+++ b/release files/momodoramoonlitfarewell/__init__.py
@@ -8,6 +8,20 @@ from .Rules import set_rules, set_completion_rules
 from worlds.AutoWorld import World, WebWorld
 from multiprocessing import Process
 
+class MomodoraWeb(WebWorld):
+    theme = "grassFlowers"
+
+    setup_en = Tutorial(
+        "Multiworld Setup Guide",
+        "A guide to setting up the Archipelago randomizer for Momodora Moonlit Farewell.",
+        "English",
+        "setup_en.md",
+        "setup/en",
+        ["alditoOt"]
+    )
+
+    tutorials = [setup_en]
+
 class MomodoraWorld(World):
     """
     Momodora Moonlit Farewell is a game
@@ -19,6 +33,8 @@ class MomodoraWorld(World):
     item_name_to_id = {name: data.code for name, data in item_table.items()}
     location_name_to_id = {name: data.id for name, data in advancement_table.items()}
     
+    web = MomodoraWeb()
+
 
     def _get_momodora_data(self):
         return {


### PR DESCRIPTION
This PR adds a WebWorld for Momodora, and instantiates it in the game's World class. This allows Momodora to appear in the Supported Games list on the Archipelago website when self-hosting (since all installed AP worlds with valid WebWorlds will appear in the list).

No other changes were made, so the game description and setup guide are still placeholders, and there is currently no game page (clicking the link to it leads to a 404).

<img width="1493" height="310" alt="WebHost - Momodora Moonlit Farewell" src="https://github.com/user-attachments/assets/7d142d4d-c225-4026-a0f6-fcf4fb1eeb2d" />

<img width="1851" height="1525" alt="WebHost - Momodora Moonlit Farewell, Options Page" src="https://github.com/user-attachments/assets/72b894b0-c978-4978-ba93-0e7618e94b3b" />
